### PR TITLE
Implement per-rule metrics and add FreeBSD support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mischief/pf_exporter
 go 1.21.12
 
 require (
-	github.com/mischief/gopf v0.0.0-20240929051726-ccbbbc6db7da
+	github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6
 	github.com/prometheus/client_golang v1.20.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/mischief/gopf v0.0.0-20240929044818-97272bc4a0b6 h1:R6TMfBBFb2LLXUGtbvfry363p99c+KXRR5B6oqvRXP8=
-github.com/mischief/gopf v0.0.0-20240929044818-97272bc4a0b6/go.mod h1:kGj0Ead6nsFvzaBKNO0YV+bKMlwdBATtNcDEAH9RB78=
-github.com/mischief/gopf v0.0.0-20240929051726-ccbbbc6db7da h1:Fpoz81k2OYGKIPnW/3BKeGtImvVd+ReYPliBF94SnRI=
-github.com/mischief/gopf v0.0.0-20240929051726-ccbbbc6db7da/go.mod h1:kGj0Ead6nsFvzaBKNO0YV+bKMlwdBATtNcDEAH9RB78=
+github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6 h1:KnsE/mXsMtwrtrMjUzlM1nYfJylG8roowSq/Y3VFCdI=
+github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6/go.mod h1:kGj0Ead6nsFvzaBKNO0YV+bKMlwdBATtNcDEAH9RB78=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/prometheus/client_golang v1.20.4 h1:Tgh3Yr67PaOv/uTqloMsCEdeuFTatm5zIq5+qNN23vI=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"sync"
@@ -39,27 +40,34 @@ func (e *PfExporter) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		log.Printf("failed to get pf stats: %v", err)
 	} else {
+		enabled := 0.0
+		if stats.Enabled() {
+			enabled = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(e.metrics["enabled"], prometheus.GaugeValue, enabled)
 		ch <- prometheus.MustNewConstMetric(e.metrics["state_total"], prometheus.GaugeValue, float64(stats.StateCount()))
 		ch <- prometheus.MustNewConstMetric(e.metrics["state_searches"], prometheus.CounterValue, float64(stats.StateSearches()))
 		ch <- prometheus.MustNewConstMetric(e.metrics["state_inserts"], prometheus.CounterValue, float64(stats.StateInserts()))
 		ch <- prometheus.MustNewConstMetric(e.metrics["state_removals"], prometheus.CounterValue, float64(stats.StateRemovals()))
 	}
 
-	ifstats := stats.IfStats()
-	if ifstats != nil {
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_bytes_in"], prometheus.CounterValue, float64(ifstats.IPv4.BytesIn))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_bytes_out"], prometheus.CounterValue, float64(ifstats.IPv4.BytesOut))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_in_passed"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsInPassed))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_in_blocked"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsInBlocked))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_out_passed"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsOutPassed))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_out_blocked"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsOutBlocked))
+	if stats != nil {
+		ifstats := stats.IfStats()
+		if ifstats != nil {
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_bytes_in"], prometheus.CounterValue, float64(ifstats.IPv4.BytesIn))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_bytes_out"], prometheus.CounterValue, float64(ifstats.IPv4.BytesOut))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_in_passed"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsInPassed))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_in_blocked"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsInBlocked))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_out_passed"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsOutPassed))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv4_packets_out_blocked"], prometheus.CounterValue, float64(ifstats.IPv4.PacketsOutBlocked))
 
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_bytes_in"], prometheus.CounterValue, float64(ifstats.IPv6.BytesIn))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_bytes_out"], prometheus.CounterValue, float64(ifstats.IPv6.BytesOut))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_in_passed"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsInPassed))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_in_blocked"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsInBlocked))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_out_passed"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsOutPassed))
-		ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_out_blocked"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsOutBlocked))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_bytes_in"], prometheus.CounterValue, float64(ifstats.IPv6.BytesIn))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_bytes_out"], prometheus.CounterValue, float64(ifstats.IPv6.BytesOut))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_in_passed"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsInPassed))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_in_blocked"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsInBlocked))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_out_passed"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsOutPassed))
+			ch <- prometheus.MustNewConstMetric(e.metrics["ipv6_packets_out_blocked"], prometheus.CounterValue, float64(ifstats.IPv6.PacketsOutBlocked))
+		}
 	}
 
 	queues, err := e.fw.Queues()
@@ -72,6 +80,45 @@ func (e *PfExporter) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(e.metrics["queue_dropped_packets"], prometheus.CounterValue, float64(queue.Stats.DroppedPackets), queue.Name, queue.IfName)
 			ch <- prometheus.MustNewConstMetric(e.metrics["queue_dropped_bytes"], prometheus.CounterValue, float64(queue.Stats.DroppedBytes), queue.Name, queue.IfName)
 		}
+	}
+
+	e.collectRulesForAnchor(ch, "")
+
+	anchors, err := e.fw.Anchors()
+	if err != nil {
+		log.Printf("failed to get anchors: %v", err)
+	} else {
+		for _, a := range anchors {
+			if a != "" {
+				e.collectRulesForAnchor(ch, a)
+			}
+		}
+	}
+}
+
+// collectRulesForAnchor emits per-rule metrics for the named anchor ("" = root ruleset).
+func (e *PfExporter) collectRulesForAnchor(ch chan<- prometheus.Metric, aname string) {
+	anchor, err := e.fw.Anchor(aname)
+	if err != nil {
+		log.Printf("failed to get anchor %q: %v", aname, err)
+		return
+	}
+
+	rules, err := anchor.RuleStats()
+	if err != nil {
+		log.Printf("failed to get rules for anchor %q: %v", aname, err)
+		return
+	}
+
+	for _, r := range rules {
+		labels := []string{fmt.Sprintf("%d", r.Nr), r.AF, r.Proto, r.Label, r.Anchor, r.Interface, r.Action, r.Direction}
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_evaluations"], prometheus.CounterValue, float64(r.Evaluations), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_packets_in"], prometheus.CounterValue, float64(r.PacketsIn), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_packets_out"], prometheus.CounterValue, float64(r.PacketsOut), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_bytes_in"], prometheus.CounterValue, float64(r.BytesIn), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_bytes_out"], prometheus.CounterValue, float64(r.BytesOut), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_states_cur"], prometheus.GaugeValue, float64(r.StatesCur), labels...)
+		ch <- prometheus.MustNewConstMetric(e.metrics["rule_states_tot"], prometheus.CounterValue, float64(r.StatesTot), labels...)
 	}
 }
 
@@ -91,6 +138,11 @@ func NewPfExporter() (*PfExporter, error) {
 	exp := &PfExporter{
 		fw: fw,
 		metrics: map[string]*prometheus.Desc{
+			"enabled": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "", "enabled"),
+				"Whether pf is enabled (1 = enabled, 0 = disabled).",
+				nil,
+				nil),
 			"state_total": prometheus.NewDesc(
 				prometheus.BuildFQName(Namespace, "state", "total"),
 				"Number of pf states.",
@@ -192,6 +244,42 @@ func NewPfExporter() (*PfExporter, error) {
 				prometheus.BuildFQName(Namespace, "stats", "queue_dropped_bytes_total"),
 				"Number of dropped bytes in a queue partitioned by queue name and interface.",
 				[]string{"queue", "interface"},
+				nil),
+
+			"rule_evaluations": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "evaluations_total"),
+				"Number of times a pf rule was evaluated.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_packets_in": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "packets_in_total"),
+				"Number of inbound packets matched by a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_packets_out": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "packets_out_total"),
+				"Number of outbound packets matched by a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_bytes_in": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "bytes_in_total"),
+				"Number of inbound bytes matched by a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_bytes_out": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "bytes_out_total"),
+				"Number of outbound bytes matched by a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_states_cur": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "states_current"),
+				"Current number of active states for a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
+				nil),
+			"rule_states_tot": prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, "rule", "states_total"),
+				"Total number of states created by a pf rule.",
+				[]string{"nr", "af", "proto", "rule", "anchor", "interface", "action", "direction"},
 				nil),
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds FreeBSD support — the exporter now builds and runs on both FreeBSD and OpenBSD
- Adds per-rule metrics via the new `RuleStats()` method on `pf.Anchor`, picking up the updated `github.com/mischief/gopf`
- Rule metrics carry labels for `nr`, `af`, `proto`, `rule`, `anchor`, `interface`, `action`, and `direction`, allowing fine-grained filtering in dashboards
- Collects rule stats from the root ruleset and all named anchors; anchors with no rules loaded are silently skipped

## New metrics

| Metric | Type | Description |
|--------|------|-------------|
| `pf_rule_evaluations_total` | counter | Times a rule was evaluated |
| `pf_rule_packets_in_total` | counter | Inbound packets matched |
| `pf_rule_packets_out_total` | counter | Outbound packets matched |
| `pf_rule_bytes_in_total` | counter | Inbound bytes matched |
| `pf_rule_bytes_out_total` | counter | Outbound bytes matched |
| `pf_rule_states_current` | gauge | Active states for a rule |
| `pf_rule_states_total` | counter | Total states created by a rule |

Tested on FreeBSD 14.
