### PR TITLE
Update gopf for recursive anchors handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mischief/pf_exporter
 go 1.21.12
 
 require (
-	github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6
+	github.com/mischief/gopf v0.0.0-20260415205714-6744eac16e2f
 	github.com/prometheus/client_golang v1.20.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6 h1:KnsE/mXsMtwrtrMjUzlM1nYfJylG8roowSq/Y3VFCdI=
 github.com/mischief/gopf v0.0.0-20260413190705-be6edce3a4f6/go.mod h1:kGj0Ead6nsFvzaBKNO0YV+bKMlwdBATtNcDEAH9RB78=
+github.com/mischief/gopf v0.0.0-20260415205714-6744eac16e2f h1:JcXe21SYiOUooswGUHUSEfy2D2qNWkvsWeKfACLBfF4=
+github.com/mischief/gopf v0.0.0-20260415205714-6744eac16e2f/go.mod h1:kGj0Ead6nsFvzaBKNO0YV+bKMlwdBATtNcDEAH9RB78=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/prometheus/client_golang v1.20.4 h1:Tgh3Yr67PaOv/uTqloMsCEdeuFTatm5zIq5+qNN23vI=


### PR DESCRIPTION
Here we update `gopf` to include https://github.com/mischief/gopf/commit/6744eac16e2f69c4464ff4972073c81c95d2f272 which will allow the anchors to recurse and provide the metrics for the sub-anchors.